### PR TITLE
Do not ignore koThreshold and warnThreshold options

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,8 +36,8 @@ exports.badge = function(options, callback) {
 	options.okColor = options.okColor || 'brightgreen';
 	options.warnColor = options.warnColor || 'orange';
 	options.koColor = options.koColor || 'red';
-	options.warnThreshold = 80;
-	options.koThreshold = 60;
+	options.warnThreshold = options.warnThreshold || 80;
+	options.koThreshold = options.koThreshold || 60;
 	options.subject = options.subject || 'coverage';
 
 	exports.linesRatio(options.filePath, function(err, ratio	){


### PR DESCRIPTION
Currently, the `koThreshold` and `warnThreshold` options are ignored although it is documented as active.
This PR enables these options.